### PR TITLE
SmarAct plugin: epsilon=2nm seems to work better

### DIFF
--- a/pymodaq_plugins/daq_move_plugins/daq_move_SmarActMCS.py
+++ b/pymodaq_plugins/daq_move_plugins/daq_move_SmarActMCS.py
@@ -52,7 +52,7 @@ class DAQ_Move_SmarActMCS(DAQ_Move_base):
         super(DAQ_Move_SmarActMCS, self).__init__(parent, params_state)
 
         self.controller = None
-        self.settings.child(('epsilon')).setValue(0.001)
+        self.settings.child(('epsilon')).setValue(0.002)
 
     def ini_stage(self, controller=None):
         """


### PR DESCRIPTION
With DAQ_Scan and epsilon = 1 nm, the time of the steps of the scan are hot homogeneous. Probably because it is waiting for polling. Epsilon = 2 nm seems to fix the problem. 